### PR TITLE
Clean active

### DIFF
--- a/dist/ui/components/Job.d.ts
+++ b/dist/ui/components/Job.d.ts
@@ -2,7 +2,7 @@
 import { AppJob } from '../../@types/app';
 export declare const Job: ({ job, status, queueName, retryJob, cleanJob, promoteJob, }: {
     job: AppJob;
-    status: "active" | "failed" | "waiting" | "paused" | "completed" | "delayed" | "latest";
+    status: "latest" | "active" | "waiting" | "completed" | "failed" | "delayed" | "paused";
     queueName: string;
     cleanJob: (job: AppJob) => () => Promise<void>;
     retryJob: (job: AppJob) => () => Promise<void>;

--- a/dist/ui/components/JobPagination.d.ts
+++ b/dist/ui/components/JobPagination.d.ts
@@ -2,5 +2,5 @@
 import { AppQueue } from '../../@types/app';
 export declare const JobPagination: ({ queue, status, }: {
     queue: AppQueue;
-    status: "active" | "failed" | "waiting" | "paused" | "completed" | "delayed" | "latest";
+    status: "latest" | "active" | "waiting" | "completed" | "failed" | "delayed" | "paused";
 }) => JSX.Element;

--- a/dist/ui/components/Jobs.d.ts
+++ b/dist/ui/components/Jobs.d.ts
@@ -5,5 +5,5 @@ export declare const Jobs: ({ retryJob, cleanJob, promoteJob, queue, status, }: 
     cleanJob: (job: AppJob) => () => Promise<void>;
     promoteJob: (job: AppJob) => () => Promise<void>;
     queue: AppQueue;
-    status: "active" | "failed" | "waiting" | "paused" | "completed" | "delayed" | "latest";
+    status: "latest" | "active" | "waiting" | "completed" | "failed" | "delayed" | "paused";
 }) => JSX.Element;

--- a/dist/ui/components/QueueActions.d.ts
+++ b/dist/ui/components/QueueActions.d.ts
@@ -4,11 +4,12 @@ import { AppQueue } from '../../@types/app';
 interface QueueActionProps {
     status: Status;
     queue: AppQueue;
+    cleanAllActive: () => Promise<void>;
     cleanAllDelayed: () => Promise<void>;
     cleanAllFailed: () => Promise<void>;
     cleanAllCompleted: () => Promise<void>;
     cleanAllWaiting: () => Promise<void>;
     retryAll: () => Promise<void>;
 }
-export declare const QueueActions: ({ status, retryAll, cleanAllFailed, cleanAllDelayed, cleanAllCompleted, cleanAllWaiting, }: QueueActionProps) => JSX.Element;
+export declare const QueueActions: ({ status, retryAll, cleanAllActive, cleanAllFailed, cleanAllDelayed, cleanAllCompleted, cleanAllWaiting, }: QueueActionProps) => JSX.Element;
 export {};

--- a/dist/ui/components/hooks/useStore.d.ts
+++ b/dist/ui/components/hooks/useStore.d.ts
@@ -16,6 +16,7 @@ export interface Store {
     retryJob: (queueName: string) => (job: AppJob) => () => Promise<void>;
     cleanJob: (queueName: string) => (job: AppJob) => () => Promise<void>;
     retryAll: (queueName: string) => () => Promise<void>;
+    cleanAllActive: (queueName: string) => () => Promise<void>;
     cleanAllDelayed: (queueName: string) => () => Promise<void>;
     cleanAllFailed: (queueName: string) => () => Promise<void>;
     cleanAllCompleted: (queueName: string) => () => Promise<void>;

--- a/src/ui/components/QueueActions.tsx
+++ b/src/ui/components/QueueActions.tsx
@@ -3,6 +3,7 @@ import { Status } from './constants'
 import { AppQueue } from '../../@types/app'
 
 const ACTIONABLE_STATUSES: Array<Status> = [
+  'active',
   'failed',
   'delayed',
   'completed',
@@ -12,6 +13,7 @@ const ACTIONABLE_STATUSES: Array<Status> = [
 interface QueueActionProps {
   status: Status
   queue: AppQueue
+  cleanAllActive: () => Promise<void>
   cleanAllDelayed: () => Promise<void>
   cleanAllFailed: () => Promise<void>
   cleanAllCompleted: () => Promise<void>
@@ -25,6 +27,7 @@ const isStatusActionable = (status: Status): boolean =>
 export const QueueActions = ({
   status,
   retryAll,
+  cleanAllActive,
   cleanAllFailed,
   cleanAllDelayed,
   cleanAllCompleted,
@@ -45,6 +48,11 @@ export const QueueActions = ({
             Clean all
           </button>
         </div>
+      )}
+      {status === 'active' && (
+        <button style={{ margin: 10 }} onClick={cleanAllActive}>
+          Clean all
+        </button>
       )}
       {status === 'delayed' && (
         <button style={{ margin: 10 }} onClick={cleanAllDelayed}>

--- a/src/ui/components/constants.ts
+++ b/src/ui/components/constants.ts
@@ -25,7 +25,16 @@ export type Field =
   | 'clean'
 
 export const FIELDS: Record<Status, Field[]> = {
-  active: ['id', 'name', 'attempts', 'data', 'opts', 'progress', 'timestamps'],
+  active: [
+    'id',
+    'name',
+    'attempts',
+    'data',
+    'opts',
+    'progress',
+    'timestamps',
+    'clean',
+  ],
   completed: [
     'id',
     'name',

--- a/src/ui/components/hooks/useStore.ts
+++ b/src/ui/components/hooks/useStore.ts
@@ -24,6 +24,7 @@ export interface Store {
   retryJob: (queueName: string) => (job: AppJob) => () => Promise<void>
   cleanJob: (queueName: string) => (job: AppJob) => () => Promise<void>
   retryAll: (queueName: string) => () => Promise<void>
+  cleanAllActive: (queueName: string) => () => Promise<void>
   cleanAllDelayed: (queueName: string) => () => Promise<void>
   cleanAllFailed: (queueName: string) => () => Promise<void>
   cleanAllCompleted: (queueName: string) => () => Promise<void>
@@ -122,6 +123,11 @@ export const useStore = (basePath: string): Store => {
       method: 'put',
     }).then(update)
 
+  const cleanAllActive = (queueName: string) => () =>
+    fetch(`${basePath}/queues/${encodeURIComponent(queueName)}/clean/active`, {
+      method: 'put',
+    }).then(update)
+
   const cleanAllDelayed = (queueName: string) => () =>
     fetch(`${basePath}/queues/${encodeURIComponent(queueName)}/clean/delayed`, {
       method: 'put',
@@ -156,6 +162,7 @@ export const useStore = (basePath: string): Store => {
     retryJob,
     retryAll,
     cleanJob,
+    cleanAllActive,
     cleanAllDelayed,
     cleanAllFailed,
     cleanAllCompleted,

--- a/src/ui/components/routes/JobList.tsx
+++ b/src/ui/components/routes/JobList.tsx
@@ -34,6 +34,7 @@ export const JobList = (props: JobListProps) => {
       <div className="queue-navigation">
         <QueueActions
           retryAll={store.retryAll(queue.name)}
+          cleanAllActive={store.cleanAllActive(queue.name)}
           cleanAllDelayed={store.cleanAllDelayed(queue.name)}
           cleanAllFailed={store.cleanAllFailed(queue.name)}
           cleanAllCompleted={store.cleanAllCompleted(queue.name)}


### PR DESCRIPTION
- adds clean "active" status jobs
- [ ] adds clean all "active" status jobs

AFAIK these are all the changes to be made in `bull-board` but there's something broken in `bullmq` because calling `queue.clean()` with status 'active' doesn't seem to do anything.